### PR TITLE
Code cleanup

### DIFF
--- a/m_app.sh
+++ b/m_app.sh
@@ -134,21 +134,6 @@ install_dvswitch() {
 	apt update
 	apt install -y dvswitch-server
 	
-	# Check for the directory before we proceed with new update from upstream
-	if [ ! -d /usr/share/dvswitch ]; then
-		# Update the dashboard
-		wget dvswitch.org/asl3_dvswitch_dashboard.run
-		chmod +x asl3_dvswitch_dashboard.run
-		./asl3_dvswitch_dashboard.run
-	
-		#Only update apache if we are actually updating dashboard
-		# Allow Apache2 to access /tmp
-		cp /lib/systemd/system/apache2.service /etc/systemd/system/
-		sed -i 's/true/false/g' /etc/systemd/system/apache2.service
-		systemctl daemon-reload
-		systemctl restart apache2
-	fi
-	
 	# Ensure we use the default usrp port used by asterisk
 	sed -i 's/31001/34001/' /usr/share/dvswitch/include/config.php
 	


### PR DESCRIPTION
Now that dvswitch has released the updated packages, the if block can be deleted as we no longer are having to manually update the dashboard, we leave the sed statement so we set the default port to the port asl3 uses by default for the first instance as indicated in howto video