### PR TITLE
Drop supermon-ng from m_app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![MAPI Logo](https://github.com/KD5FMU/ASL3_Multi_App_Install/blob/main/MAIS.png)
 
 # AllStarLink Multiple Application Install Script
-This is an enhanced script file that will help install AllScan, DvSwitch Server, SkywarnPlus, Supermon 7.4 Fresh Install and the Upgradable Version. I mostly utilize this script to install these Apps once I setup a new ASL3 Install.
+This is an enhanced script file that will help install AllScan, DvSwitch Server, SkywarnPlus, and Supermon 7.4 Fresh Install and the Upgradable Version. I mostly utilize this script to install these Apps once I setup a new ASL3 Install.
 
 You now have the option to install SkywarnPlus, DVSwitch Server, AllScan and Supermon 7.4+ Upgrade version onto your AllStarLink version 3 node. As of this date (1/11/2025) This has been tested on the Raspberry Pi Appliance version of ASL 3.
 
@@ -55,14 +55,13 @@ Usage: ./m_app.sh [OPTIONS]
 Options:
   -a    Install allscan
   -s    Install supermon
-  -n    Install supermon-ng
   -w    Install skywarnplus
   -d    Install dvswitch
   -v    Verbose output
   -t    Dry run (test mode)
   -h    Display this help message
 
-You can combine options to install multiple software (e.g., ./m_app.sh -a -s -n).
+You can combine options to install multiple software (e.g., ./m_app.sh -a -s -w).
 ```
 
 ## 🔧 Examples
@@ -74,12 +73,12 @@ sudo ./m_app.sh -t -a -s -w
 
 **Verbose installation** - Get detailed output during installation:
 ```bash
-sudo ./m_app.sh -v -a -s -n -w -d
+sudo ./m_app.sh -v -a -s -w -d
 ```
 
 **Normal installation** - Install all applications:
 ```bash
-sudo ./m_app.sh -asnwd
+sudo ./m_app.sh -aswd
 ```
 
 **Install specific applications** - Choose only what you need:
@@ -94,7 +93,6 @@ This script will install:
 - **DVSwitch Server** - Digital Voice switching (requires PHP 8.2)
 - **SkywarnPlus** - Weather alert integration
 - **Supermon 7.4+** - Enhanced monitoring interface
-- **Supermon-NG** - Next generation monitoring (alternative to Supermon)
 
 ## 🔍 Logging & Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,55 @@
 ![MAPI Logo](https://github.com/KD5FMU/ASL3_Multi_App_Install/blob/main/MAIS.png)
 
 # AllStarLink Multiple Application Install Script
-This is a script file that will help install AllScan, DvSwitch Server, SkywarnPlus, Supermon 7.4 Fresh Install and the Upgradable Version. I mostly utilize this script to install these Apps once I setup a new ASL3 Install.
+This is an enhanced script file that will help install AllScan, DvSwitch Server, SkywarnPlus, Supermon 7.4 Fresh Install and the Upgradable Version. I mostly utilize this script to install these Apps once I setup a new ASL3 Install.
 
-You now have the option to install, SkywarnPlus, DVSwitch Server, AllScan and Supermon 7.4+ Upgrade verison onto your AllStarLink version 3 node. As of this date (1/11/2025) This has been tested on the Raspberry Pi Appliance version of ASL 3,
+You now have the option to install SkywarnPlus, DVSwitch Server, AllScan and Supermon 7.4+ Upgrade version onto your AllStarLink version 3 node. As of this date (1/11/2025) This has been tested on the Raspberry Pi Appliance version of ASL 3.
 
 This has also been tested on Debian 12 versions.
 
+## 🚀 New Features & Improvements
 
+The script has been significantly enhanced with:
+- **Error handling & robustness** - Comprehensive error checking and retry logic
+- **Logging system** - Detailed logs saved to `/var/log/m_app_install.log`
+- **Dry-run mode** - Test installations without making changes (`-t` flag)
+- **Verbose output** - Detailed debugging information (`-v` flag)
+- **Smart dependency management** - Only installs missing packages
+- **Configuration backups** - Automatic backups before modifications
+- **Better user feedback** - Colored output and progress indicators
 
-Once you have done a basic setup of the new ASL 3 node install you can now safely download and run the before mentioned script file. Go to the root directory by executing the following command:
+## 📋 Prerequisites
 
-```
+- AllStarLink version 3 installed and configured
+- Root or sudo access
+- Internet connection for downloads
+- For DVSwitch: PHP 8.2 must be available in your package repositories
+
+## 🛠️ Installation
+
+Once you have done a basic setup of the new ASL 3 node install you can now safely download and run the script file. Go to the root directory by executing the following command:
+
+```bash
 cd
 ```
 
 Then we can download the script file with this command:
 
-```
+```bash
 wget https://raw.githubusercontent.com/KD5FMU/ASL3_Multi_App_Install/refs/heads/main/m_app.sh
 ```
 
 Then once the download has finished we need to make the newly downloaded script file executable. We can do this with the following command:
 
-```
+```bash
 chmod +x m_app.sh
 ```
+
+## 📖 Usage
+
 You now have options that can be passed to the script to install the applications that you desire.
-```
+
+```bash
 Usage: ./m_app.sh [OPTIONS]
 
 Options:
@@ -36,22 +58,65 @@ Options:
   -n    Install supermon-ng
   -w    Install skywarnplus
   -d    Install dvswitch
+  -v    Verbose output
+  -t    Dry run (test mode)
   -h    Display this help message
 
 You can combine options to install multiple software (e.g., ./m_app.sh -a -s -n).
 ```
 
-Then once that is down you can go ahead and run the script file with this command: This is an example please pick the applications you are wanting.
+## 🔧 Examples
 
+**Test mode** - See what would be installed without making changes:
+```bash
+sudo ./m_app.sh -t -a -s -w
 ```
+
+**Verbose installation** - Get detailed output during installation:
+```bash
+sudo ./m_app.sh -v -a -s -n -w -d
+```
+
+**Normal installation** - Install all applications:
+```bash
 sudo ./m_app.sh -asnwd
 ```
 
-This will take a little while to install and you will encounter some prompts for information. Please answer them as you see needed but most of them, if not all, will most likely be a yes answer. But if you are a more advanced user then you can make whatever choice you wish.
+**Install specific applications** - Choose only what you need:
+```bash
+sudo ./m_app.sh -w -s  # Install only SkywarnPlus and Supermon
+```
 
-This script will install AllScan, DVSwitch Server, SkywarnPlus and Supermon 7.4+ 
+## 📝 What Gets Installed
 
-It is my wish that you find this script file useful.
+This script will install:
+- **AllScan** - Dashboard for AllStarLink monitoring
+- **DVSwitch Server** - Digital Voice switching (requires PHP 8.2)
+- **SkywarnPlus** - Weather alert integration
+- **Supermon 7.4+** - Enhanced monitoring interface
+- **Supermon-NG** - Next generation monitoring (alternative to Supermon)
+
+## 🔍 Logging & Troubleshooting
+
+- **Log file**: `/var/log/m_app_install.log`
+- **Configuration backups**: Stored as `.bak-*` files
+- **Temporary files**: Automatically cleaned up after installation
+
+## ⚠️ Important Notes
+
+- The script must be run as root or with sudo
+- DVSwitch requires PHP 8.2 specifically
+- Configuration files are automatically backed up before modification
+- Use dry-run mode (`-t`) to test before actual installation
+- Check the log file for detailed installation information
+
+## 🤝 Contributing
+
+This script has been enhanced with community feedback and continues to be improved. If you encounter issues or have suggestions, please report them through the GitHub repository.
+
+---
+
+It is my wish that you find this enhanced script file useful.
 
 73 DE KD5FMU
 

--- a/m_app.sh
+++ b/m_app.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script assists with the new install of AllStarLink version 3.
 # It installs SkywarnPlus, AllScan Dashboard, DVSwitch Server, and Supermon 7.4+.
@@ -21,17 +21,109 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+# Configuration
+CONF_FILE="/etc/asterisk/rpt.conf"
+LOG_FILE="/var/log/m_app_install.log"
+TEMP_DIR="/tmp/m_app_install"
+DRY_RUN=false
+VERBOSE=false
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging function
+log() {
+    local level=$1
+    shift
+    local message="$*"
+    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    
+    case $level in
+        INFO)
+            echo -e "${GREEN}[INFO]${NC} $message"
+            ;;
+        WARN)
+            echo -e "${YELLOW}[WARN]${NC} $message"
+            ;;
+        ERROR)
+            echo -e "${RED}[ERROR]${NC} $message"
+            ;;
+        DEBUG)
+            if [ "$VERBOSE" = true ]; then
+                echo -e "${BLUE}[DEBUG]${NC} $message"
+            fi
+            ;;
+    esac
+    
+    echo "[$timestamp] [$level] $message" >> "$LOG_FILE"
+}
+
+# Error handling function
+error_exit() {
+    log ERROR "$1"
+    exit 1
+}
+
 # Check if root
 if [ "$(id -u)" -ne 0 ]; then
-    echo "This script must be run as root or with sudo"
-    exit 1
+    error_exit "This script must be run as root or with sudo"
 fi
 
-CONF_FILE="/etc/asterisk/rpt.conf"
+# Create temp directory and log file
+mkdir -p "$TEMP_DIR"
+touch "$LOG_FILE"
+
+log INFO "Starting M-Apps installation script"
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to check if a package is installed
+package_installed() {
+    dpkg -l "$1" >/dev/null 2>&1
+}
+
+# Function to safely download files
+safe_download() {
+    local url="$1"
+    local output="$2"
+    local max_retries=3
+    local retry_count=0
+    
+    while [ $retry_count -lt $max_retries ]; do
+        if wget --no-verbose --timeout=30 --tries=3 -O "$output" "$url"; then
+            log DEBUG "Successfully downloaded $url"
+            return 0
+        else
+            retry_count=$((retry_count + 1))
+            log WARN "Download failed for $url (attempt $retry_count/$max_retries)"
+            [ $retry_count -lt $max_retries ] && sleep 2
+        fi
+    done
+    
+    error_exit "Failed to download $url after $max_retries attempts"
+}
+
+# Function to backup configuration file
+backup_config() {
+    local backup_suffix="$1"
+    if [ -f "$CONF_FILE" ]; then
+        cp "$CONF_FILE" "${CONF_FILE}.bak-${backup_suffix}"
+        log INFO "Configuration backed up to ${CONF_FILE}.bak-${backup_suffix}"
+    else
+        log WARN "Configuration file $CONF_FILE not found"
+    fi
+}
 
 # Function to display usage
 usage() {
-	cat << EOF
+    cat << EOF
 Usage: $0 [OPTIONS]
 
 Options:
@@ -40,6 +132,8 @@ Options:
   -n    Install supermon-ng
   -w    Install skywarnplus
   -d    Install dvswitch
+  -v    Verbose output
+  -t    Dry run (test mode)
   -h    Display this help message
 
 You can combine options to install multiple software (e.g., $0 -a -s -n).
@@ -48,144 +142,315 @@ EOF
 
 # Functions to install each software package
 install_allscan() {
-	echo "Installing allscan..."
-	# First make sure required deps are installed
-	apt install php unzip -y
-	cd || exit
-	wget 'https://raw.githubusercontent.com/davidgsd/AllScan/main/AllScanInstallUpdate.php'
-	chmod 755 AllScanInstallUpdate.php
-	./AllScanInstallUpdate.php
-	rm -f AllScanInstallUpdate.php
-	echo "Allscan installation complete."
+    log INFO "Installing AllScan..."
+    
+    if [ "$DRY_RUN" = true ]; then
+        log INFO "[DRY RUN] Would install AllScan"
+        return 0
+    fi
+    
+    # Check dependencies
+    local deps=("php" "unzip")
+    for dep in "${deps[@]}"; do
+        if ! package_installed "$dep"; then
+            log INFO "Installing dependency: $dep"
+            apt install -y "$dep" || error_exit "Failed to install $dep"
+        fi
+    done
+    
+    cd "$TEMP_DIR" || error_exit "Failed to change to temp directory"
+    
+    local installer="AllScanInstallUpdate.php"
+    safe_download "https://raw.githubusercontent.com/davidgsd/AllScan/main/AllScanInstallUpdate.php" "$installer"
+    chmod 755 "$installer"
+    
+    log INFO "Running AllScan installer..."
+    if ./"$installer"; then
+        log INFO "AllScan installation completed successfully"
+    else
+        error_exit "AllScan installation failed"
+    fi
+    
+    rm -f "$installer"
 }
 
 install_supermon() {
-	echo "Installing supermon..."
-	# Install deps before we fetch script and run
-	apt -y install apache2 php libapache2-mod-php libcgi-session-perl bc
-	cd || exit
-	wget "http://2577.asnode.org:43856/supermonASL_fresh_install" -O supermonASL_fresh_install
-	chmod +x supermonASL_fresh_install
-	./supermonASL_fresh_install
-	echo "Supermon 7.4+ fresh installation complete."
-	
-	echo "Installing Upgradeable Supermon 7.4..."
-	wget "http://2577.asnode.org:43856/supermonASL_latest_update" -O supermonASL_latest_update
-	chmod +x supermonASL_latest_update
-	./supermonASL_latest_update
-	rm -f supermonASL_fresh_install supermonASL_latest_update
-
-	cp "$CONF_FILE" "${CONF_FILE}.bak-supermon"
-	sed -i '/\[functions\]/a SMUPDATE=cmd,/usr/local/sbin/supermonASL_latest_update \n' "$CONF_FILE"
-
-	echo "Setting up cron job..."
-	DISABLE_MAIL="MAILTO=\"\""
-	CRON_COMMENT="# Supermon 7.4 updater crontab entry"
-	CRON_JOB="0 3 * * * /var/www/html/supermon/astdb.php cron"
-	( crontab -l 2>/dev/null; echo "$DISABLE_MAIL"; echo "$CRON_COMMENT"; echo "$CRON_JOB" ) | crontab -
-	echo "Cron job set."
-
-	echo "Upgradeable Supermon 7.4 install complete."
+    log INFO "Installing Supermon..."
+    
+    if [ "$DRY_RUN" = true ]; then
+        log INFO "[DRY RUN] Would install Supermon"
+        return 0
+    fi
+    
+    # Install dependencies
+    local deps=("apache2" "php" "libapache2-mod-php" "libcgi-session-perl" "bc")
+    for dep in "${deps[@]}"; do
+        if ! package_installed "$dep"; then
+            log INFO "Installing dependency: $dep"
+            apt install -y "$dep" || error_exit "Failed to install $dep"
+        fi
+    done
+    
+    cd "$TEMP_DIR" || error_exit "Failed to change to temp directory"
+    
+    # Download and run fresh install
+    safe_download "http://2577.asnode.org:43856/supermonASL_fresh_install" "supermonASL_fresh_install"
+    chmod +x supermonASL_fresh_install
+    
+    log INFO "Running Supermon fresh install..."
+    if ./supermonASL_fresh_install; then
+        log INFO "Supermon 7.4+ fresh installation completed"
+    else
+        error_exit "Supermon fresh installation failed"
+    fi
+    
+    # Download and run latest update
+    safe_download "http://2577.asnode.org:43856/supermonASL_latest_update" "supermonASL_latest_update"
+    chmod +x supermonASL_latest_update
+    
+    log INFO "Running Supermon latest update..."
+    if ./supermonASL_latest_update; then
+        log INFO "Supermon 7.4+ update completed"
+    else
+        error_exit "Supermon update failed"
+    fi
+    
+    # Cleanup
+    rm -f supermonASL_fresh_install supermonASL_latest_update
+    
+    # Backup and modify configuration
+    backup_config "supermon"
+    
+    if [ -f "$CONF_FILE" ]; then
+        # Add SMUPDATE function if not already present
+        if ! grep -q "SMUPDATE=" "$CONF_FILE"; then
+            sed -i '/\[functions\]/a SMUPDATE=cmd,/usr/local/sbin/supermonASL_latest_update' "$CONF_FILE"
+            log INFO "Added SMUPDATE function to configuration"
+        fi
+    fi
+    
+    # Setup cron job
+    log INFO "Setting up cron job..."
+    local disable_mail="MAILTO=\"\""
+    local cron_comment="# Supermon 7.4 updater crontab entry"
+    local cron_job="0 3 * * * /var/www/html/supermon/astdb.php cron"
+    
+    # Check if cron job already exists
+    if ! crontab -l 2>/dev/null | grep -q "astdb.php cron"; then
+        ( crontab -l 2>/dev/null; echo "$disable_mail"; echo "$cron_comment"; echo "$cron_job" ) | crontab -
+        log INFO "Cron job added successfully"
+    else
+        log INFO "Cron job already exists, skipping"
+    fi
+    
+    log INFO "Supermon installation completed successfully"
 }
 
 install_supermon_ng() {
-	echo "Installing supermon-ng..."
-	# Install deps before we fetch script and run
-	apt install -y apache2 php libapache2-mod-php libcgi-session-perl bc acl curl tar coreutils sudo rsync
-	cd || exit
-	wget "https://raw.githubusercontent.com/hardenedpenguin/supermon-ng/refs/heads/main/supermon-ng-installer.sh" -O supermon-ng-installer.sh
-	chmod +x supermon-ng-installer.sh
-	./supermon-ng-installer.sh
-	rm -f supermon-ng-installer.sh
-	echo "Supermon-NG installation complete."
+    log INFO "Installing Supermon-NG..."
+    
+    if [ "$DRY_RUN" = true ]; then
+        log INFO "[DRY RUN] Would install Supermon-NG"
+        return 0
+    fi
+    
+    # Install dependencies
+    local deps=("apache2" "php" "libapache2-mod-php" "libcgi-session-perl" "bc" "acl" "curl" "tar" "coreutils" "sudo" "rsync")
+    for dep in "${deps[@]}"; do
+        if ! package_installed "$dep"; then
+            log INFO "Installing dependency: $dep"
+            apt install -y "$dep" || error_exit "Failed to install $dep"
+        fi
+    done
+    
+    cd "$TEMP_DIR" || error_exit "Failed to change to temp directory"
+    
+    safe_download "https://raw.githubusercontent.com/hardenedpenguin/supermon-ng/refs/heads/main/supermon-ng-installer.sh" "supermon-ng-installer.sh"
+    chmod +x supermon-ng-installer.sh
+    
+    log INFO "Running Supermon-NG installer..."
+    if ./supermon-ng-installer.sh; then
+        log INFO "Supermon-NG installation completed successfully"
+    else
+        error_exit "Supermon-NG installation failed"
+    fi
+    
+    rm -f supermon-ng-installer.sh
 }
 
 install_skywarnplus() {
-	echo "Installing skywarnplus..."
-	# Install deps before we install skywarn via script
-	apt install -y unzip python3 python3-pip ffmpeg python3-ruamel.yaml python3-requests python3-dateutil python3-pydub
-	cd || exit
-	bash -c "$(curl -fsSL https://raw.githubusercontent.com/Mason10198/SkywarnPlus/main/swp-install)"
-
-	cp "$CONF_FILE" "${CONF_FILE}.bak-skywarn"
-	sed -i '/\[functions\]/a \
-831 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py enable toggle ; Toggles SkywarnPlus \
-832 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py sayalert toggle ; Toggles SayAlert \
-833 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py sayallclear toggle ; Toggles SayAllClear \
-834 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py tailmessage toggle ; Toggles TailMessage \
-835 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py courtesytone toggle ; Toggles CourtesyTone \
-836 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py alertscript toggle ; Toggles AlertScript \
-837 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py idchange toggle ; Toggles IDChange \
-838 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py changect normal ; Forces CT to "normal" mode \
-839 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py changeid normal ; Forces ID to "normal" mode \
-841 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 1 ; SkyDescribe the 1st alert \
-842 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 2 ; SkyDescribe the 2nd alert \
-843 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 3 ; SkyDescribe the 3rd alert \
-844 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 4 ; SkyDescribe the 4th alert \
-845 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 5 ; SkyDescribe the 5th alert \
-846 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 6 ; SkyDescribe the 6th alert \
-847 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 7 ; SkyDescribe the 7th alert \
-848 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 8 ; SkyDescribe the 8th alert \
-849 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 9 ; SkyDescribe the 9th alert \n' "$CONF_FILE"
-
-	sed -i '/tailmessagetime=/s/^#//; s/tailmessagetime=.*/tailmessagetime=600000/' "$CONF_FILE"
-	sed -i '/tailsquashedtime=/s/^#//; s/tailsquashedtime=.*/tailsquashedtime=30000/' "$CONF_FILE"
-	awk '/tailsquashedtime=30000/ { print "tailmessagelist = /tmp/SkywarnPlus/wx-tail"; } { print }' "$CONF_FILE" > "${CONF_FILE}.tmp" && mv "${CONF_FILE}.tmp" "$CONF_FILE"
-	
-	echo "Skywarnplus installation complete."
+    log INFO "Installing SkywarnPlus..."
+    
+    if [ "$DRY_RUN" = true ]; then
+        log INFO "[DRY RUN] Would install SkywarnPlus"
+        return 0
+    fi
+    
+    # Install dependencies
+    local deps=("unzip" "python3" "python3-pip" "ffmpeg" "python3-ruamel.yaml" "python3-requests" "python3-dateutil" "python3-pydub")
+    for dep in "${deps[@]}"; do
+        if ! package_installed "$dep"; then
+            log INFO "Installing dependency: $dep"
+            apt install -y "$dep" || error_exit "Failed to install $dep"
+        fi
+    done
+    
+    cd "$TEMP_DIR" || error_exit "Failed to change to temp directory"
+    
+    log INFO "Running SkywarnPlus installer..."
+    if bash -c "$(curl -fsSL https://raw.githubusercontent.com/Mason10198/SkywarnPlus/main/swp-install)"; then
+        log INFO "SkywarnPlus installation completed"
+    else
+        error_exit "SkywarnPlus installation failed"
+    fi
+    
+    # Backup and modify configuration
+    backup_config "skywarn"
+    
+    if [ -f "$CONF_FILE" ]; then
+        # Add SkywarnPlus functions if not already present
+        if ! grep -q "SkywarnPlus/SkyControl.py" "$CONF_FILE"; then
+            # Insert SkywarnPlus functions after the [functions] stanza
+            sed -i '/\[functions\]/a \
+831 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py enable toggle ; Toggles SkywarnPlus\
+832 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py sayalert toggle ; Toggles SayAlert\
+833 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py sayallclear toggle ; Toggles SayAllClear\
+834 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py tailmessage toggle ; Toggles TailMessage\
+835 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py courtesytone toggle ; Toggles CourtesyTone\
+836 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py alertscript toggle ; Toggles AlertScript\
+837 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py idchange toggle ; Toggles IDChange\
+838 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py changect normal ; Forces CT to "normal" mode\
+839 = cmd,/usr/local/bin/SkywarnPlus/SkyControl.py changeid normal ; Forces ID to "normal" mode\
+841 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 1 ; SkyDescribe the 1st alert\
+842 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 2 ; SkyDescribe the 2nd alert\
+843 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 3 ; SkyDescribe the 3rd alert\
+844 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 4 ; SkyDescribe the 4th alert\
+845 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 5 ; SkyDescribe the 5th alert\
+846 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 6 ; SkyDescribe the 6th alert\
+847 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 7 ; SkyDescribe the 7th alert\
+848 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 8 ; SkyDescribe the 8th alert\
+849 = cmd,/usr/local/bin/SkywarnPlus/SkyDescribe.py 9 ; SkyDescribe the 9th alert' "$CONF_FILE"
+            log INFO "Added SkywarnPlus functions to [functions] stanza"
+        fi
+        
+        # Update configuration settings
+        sed -i '/tailmessagetime=/s/^#//; s/tailmessagetime=.*/tailmessagetime=600000/' "$CONF_FILE"
+        sed -i '/tailsquashedtime=/s/^#//; s/tailsquashedtime=.*/tailsquashedtime=30000/' "$CONF_FILE"
+        
+        # Add tailmessagelist if not present
+        if ! grep -q "tailmessagelist.*SkywarnPlus" "$CONF_FILE"; then
+            awk '/tailsquashedtime=30000/ { print "tailmessagelist = /tmp/SkywarnPlus/wx-tail"; } { print }' "$CONF_FILE" > "${CONF_FILE}.tmp" && mv "${CONF_FILE}.tmp" "$CONF_FILE"
+            log INFO "Added tailmessagelist configuration"
+        fi
+    fi
+    
+    log INFO "SkywarnPlus installation completed successfully"
 }
 
 install_dvswitch() {
-	echo "Installing dvswitch..."
-	# Install deps before we install dvswitch
-	apt install -y php-cgi libapache2-mod-php8.2
-	cd || exit
-	wget dvswitch.org/bookworm
-	chmod +x bookworm
-	./bookworm
-	rm bookworm
-	apt update
-	apt install -y dvswitch-server
-	
-	# Ensure we use the default usrp port used by asterisk
-	sed -i 's/31001/34001/' /usr/share/dvswitch/include/config.php
-	
-	echo "Dvswitch Server installation complete."
+    log INFO "Installing DVSwitch Server..."
+    
+    if [ "$DRY_RUN" = true ]; then
+        log INFO "[DRY RUN] Would install DVSwitch Server"
+        return 0
+    fi
+    
+    # Install dependencies
+    local deps=("php-cgi" "libapache2-mod-php8.2")
+    
+    # Check if PHP 8.2 is available
+    if ! apt list --installed | grep -q "php8.2" && ! apt list --available | grep -q "php8.2"; then
+        log ERROR "PHP 8.2 is required for DVSwitch but not available in package repositories"
+        log INFO "Please ensure PHP 8.2 is available before installing DVSwitch"
+        return 1
+    fi
+    
+    for dep in "${deps[@]}"; do
+        if ! package_installed "$dep"; then
+            log INFO "Installing dependency: $dep"
+            apt install -y "$dep" || error_exit "Failed to install $dep"
+        fi
+    done
+    
+    cd "$TEMP_DIR" || error_exit "Failed to change to temp directory"
+    
+    safe_download "dvswitch.org/bookworm" "bookworm"
+    chmod +x bookworm
+    
+    log INFO "Running DVSwitch installer..."
+    if ./bookworm; then
+        log INFO "DVSwitch installer completed"
+    else
+        error_exit "DVSwitch installer failed"
+    fi
+    
+    rm -f bookworm
+    
+    # Update package list and install DVSwitch server
+    apt update
+    apt install -y dvswitch-server || error_exit "Failed to install dvswitch-server"
+    
+    # Update USRP port configuration
+    local config_file="/usr/share/dvswitch/include/config.php"
+    if [ -f "$config_file" ]; then
+        if sed -i 's/31001/34001/' "$config_file"; then
+            log INFO "Updated USRP port from 31001 to 34001"
+        else
+            log WARN "Failed to update USRP port configuration"
+        fi
+    else
+        log WARN "DVSwitch config file not found: $config_file"
+    fi
+    
+    log INFO "DVSwitch Server installation completed successfully"
 }
 
 # Parse command-line arguments
-while getopts "aswdnh" opt; do
-	case $opt in
-		a)
-			install_allscan_flag=true
-		;;
-		s)
-			install_supermon_flag=true
-		;;
-		w)
-			install_skywarnplus_flag=true
-		;;
-		d)
-			install_dvswitch_flag=true
-		;;
-		n)
-			install_supermon_ng_flag=true
-		;;
-		h)
-			usage
-			exit 0
-		;;
-		*)
-			usage
-			exit 1
-		;;
-	esac
+while getopts "aswdnhtv" opt; do
+    case $opt in
+        a)
+            install_allscan_flag=true
+            ;;
+        s)
+            install_supermon_flag=true
+            ;;
+        w)
+            install_skywarnplus_flag=true
+            ;;
+        d)
+            install_dvswitch_flag=true
+            ;;
+        n)
+            install_supermon_ng_flag=true
+            ;;
+        t)
+            DRY_RUN=true
+            log INFO "Dry run mode enabled"
+            ;;
+        v)
+            VERBOSE=true
+            log INFO "Verbose mode enabled"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
 done
 
 # If no options are provided, show usage and exit
 if [ "$OPTIND" -eq 1 ]; then
-	usage
-	exit 1
+    usage
+    exit 1
+fi
+
+# Check if configuration file exists
+if [ ! -f "$CONF_FILE" ]; then
+    log WARN "Configuration file $CONF_FILE not found. Some installations may fail."
 fi
 
 # Perform the installations based on flags
@@ -194,3 +459,11 @@ fi
 [ "$install_supermon_ng_flag" ] && install_supermon_ng
 [ "$install_skywarnplus_flag" ] && install_skywarnplus
 [ "$install_dvswitch_flag" ] && install_dvswitch
+
+# Cleanup
+if [ "$DRY_RUN" = false ]; then
+    rm -rf "$TEMP_DIR"
+    log INFO "Installation completed. Log file: $LOG_FILE"
+else
+    log INFO "Dry run completed. No changes were made."
+fi

--- a/m_app.sh
+++ b/m_app.sh
@@ -129,14 +129,13 @@ Usage: $0 [OPTIONS]
 Options:
   -a    Install allscan
   -s    Install supermon
-  -n    Install supermon-ng
   -w    Install skywarnplus
   -d    Install dvswitch
   -v    Verbose output
   -t    Dry run (test mode)
   -h    Display this help message
 
-You can combine options to install multiple software (e.g., $0 -a -s -n).
+You can combine options to install multiple software (e.g., $0 -a -s -w).
 EOF
 }
 
@@ -246,37 +245,6 @@ install_supermon() {
     log INFO "Supermon installation completed successfully"
 }
 
-install_supermon_ng() {
-    log INFO "Installing Supermon-NG..."
-    
-    if [ "$DRY_RUN" = true ]; then
-        log INFO "[DRY RUN] Would install Supermon-NG"
-        return 0
-    fi
-    
-    # Install dependencies
-    local deps=("apache2" "php" "libapache2-mod-php" "libcgi-session-perl" "bc" "acl" "curl" "tar" "coreutils" "sudo" "rsync")
-    for dep in "${deps[@]}"; do
-        if ! package_installed "$dep"; then
-            log INFO "Installing dependency: $dep"
-            apt install -y "$dep" || error_exit "Failed to install $dep"
-        fi
-    done
-    
-    cd "$TEMP_DIR" || error_exit "Failed to change to temp directory"
-    
-    safe_download "https://raw.githubusercontent.com/hardenedpenguin/supermon-ng/refs/heads/main/supermon-ng-installer.sh" "supermon-ng-installer.sh"
-    chmod +x supermon-ng-installer.sh
-    
-    log INFO "Running Supermon-NG installer..."
-    if ./supermon-ng-installer.sh; then
-        log INFO "Supermon-NG installation completed successfully"
-    else
-        error_exit "Supermon-NG installation failed"
-    fi
-    
-    rm -f supermon-ng-installer.sh
-}
 
 install_skywarnplus() {
     log INFO "Installing SkywarnPlus..."
@@ -406,7 +374,7 @@ install_dvswitch() {
 }
 
 # Parse command-line arguments
-while getopts "aswdnhtv" opt; do
+while getopts "aswdhtv" opt; do
     case $opt in
         a)
             install_allscan_flag=true
@@ -419,9 +387,6 @@ while getopts "aswdnhtv" opt; do
             ;;
         d)
             install_dvswitch_flag=true
-            ;;
-        n)
-            install_supermon_ng_flag=true
             ;;
         t)
             DRY_RUN=true
@@ -456,7 +421,6 @@ fi
 # Perform the installations based on flags
 [ "$install_allscan_flag" ] && install_allscan
 [ "$install_supermon_flag" ] && install_supermon
-[ "$install_supermon_ng_flag" ] && install_supermon_ng
 [ "$install_skywarnplus_flag" ] && install_skywarnplus
 [ "$install_dvswitch_flag" ] && install_dvswitch
 


### PR DESCRIPTION
Need to drop supermon-ng from m_app as the setup is handled much differently. We no longer provide a script or an easy way for m_app to download unpack and setup supermon-ng.