### PR TITLE
Fix /tmp dir for permission denied

### DIFF
--- a/m_app.sh
+++ b/m_app.sh
@@ -24,7 +24,7 @@
 # Configuration
 CONF_FILE="/etc/asterisk/rpt.conf"
 LOG_FILE="/var/log/m_app_install.log"
-TEMP_DIR="/tmp/m_app_install"
+TEMP_DIR="/root/m_app_install"
 DRY_RUN=false
 VERBOSE=false
 


### PR DESCRIPTION
Move to using /root instead of /tmp so we do not end up with permission denied errors from not being able to run exectuables.